### PR TITLE
take out line that breaks squid (acl manager proto cache_object) from…

### DIFF
--- a/templates/default/squid31.conf.erb
+++ b/templates/default/squid31.conf.erb
@@ -15,7 +15,7 @@ acl localhost src 127.0.0.1/32
 acl localnet src 10.0.0.0/8	# RFC1918 possible internal network
 acl localnet src 172.16.0.0/12	# RFC1918 possible internal network
 acl localnet src 192.168.0.0/16	# RFC1918 possible internal network
-acl manager proto cache_object
+#acl manager proto cache_object
 acl purge method PURGE
 acl Safe_ports port 443		# https
 acl Safe_ports port 80		# http

--- a/templates/default/squid31.conf.erb
+++ b/templates/default/squid31.conf.erb
@@ -15,7 +15,6 @@ acl localhost src 127.0.0.1/32
 acl localnet src 10.0.0.0/8	# RFC1918 possible internal network
 acl localnet src 172.16.0.0/12	# RFC1918 possible internal network
 acl localnet src 192.168.0.0/16	# RFC1918 possible internal network
-#acl manager proto cache_object
 acl purge method PURGE
 acl Safe_ports port 443		# https
 acl Safe_ports port 80		# http


### PR DESCRIPTION
There is a bad acl line in the default template that only sometimes blows up squid.

I have removed it to let Ops sleep all night.
